### PR TITLE
const icon = bookmark?

### DIFF
--- a/firefox/background.js
+++ b/firefox/background.js
@@ -50,10 +50,15 @@ function generateShadowmapLinkFromGoogleEarth(tab) {
 browser.browserAction.onClicked.addListener(function(tab) {
 
     const tabURL = tab.url
+    
+    if(!tabURL.includes("app.shadowmap") && !tabURL.includes("google")) {
+        chrome.tabs.create("https://app.shadowmap.org/");
+        return
+    }
 
     if (tabURL.includes("app.shadowmap")) {
         const url = generateGoogleLink(tab)
-        chrome.tabs.create({ url });
+        browser.tabs.create({ url });
         return
     }
     


### PR DESCRIPTION
!Code not tested!

Clicking on the Shadowmap Icon if neither on google or shadowmap already opens app.shadowmap.org


Also I believe chrome.tabs does not work in Firefox (should be browser.tabs) – also not tested, please correct me if I'm wrong!

...I just wanted to scout for the sun on Shadowmap and felt too lazy too type ;D
If we have the icon in the browser already, why not use it as a bookmark as well ;)